### PR TITLE
Hot-patch Mac OS X overridden keybinds

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
-	{ "keys": ["ctrl+i"], "command": "renpy_text_tag", "args": {"tag": "i"} },
-	{ "keys": ["ctrl+b"], "command": "renpy_text_tag", "args": {"tag": "b"} },
-	{ "keys": ["ctrl+u"], "command": "renpy_text_tag", "args": {"tag": "u"} }
+	{ "keys": ["super+i"], "command": "renpy_text_tag", "args": {"tag": "i"} },
+	{ "keys": ["super+b"], "command": "renpy_text_tag", "args": {"tag": "b"} },
+	{ "keys": ["super+u"], "command": "renpy_text_tag", "args": {"tag": "u"} }
 ]


### PR DESCRIPTION
- Ctrl tends to do insensible things on Mac OS X at times; Sublime Text uses "super" to notate that Mac OS X users are pressing the "command" key, which is the key that most shortcuts will use on a Macintosh. (CMD+C for copy, CMD+B for bold, etc.)
