### PR TITLE
Add highlighting for local labels (preceded by .)

### DIFF
--- a/RenpyLanguage.JSON-tmLanguage
+++ b/RenpyLanguage.JSON-tmLanguage
@@ -13,7 +13,7 @@
     "patterns": [
 
         {
-            "begin": "^(\\h*)(label)(\\s+)(\\w+)((\\s*)(\\(.*\\))(\\s*))?:",
+            "begin": "^(\\h*)(label)(\\s+)(\\.?\\w+)((\\s*)(\\(.*\\))(\\s*))?:",
             "beginCaptures":{
                 "2":{"name":"keyword.control.flow.renpy"},
                 "4":{"name":"variable.renpy"}

--- a/RenpyLanguage.tmLanguage
+++ b/RenpyLanguage.tmLanguage
@@ -27,7 +27,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>^(\h*)(label)(\s+)(\w+)((\s*)(\(.*\))(\s*))?:</string>
+			<string>^(\h*)(label)(\s+)(\.?\w+)((\s*)(\(.*\))(\s*))?:</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>


### PR DESCRIPTION
Not sure if these were left out intentionally, but with this change [local labels](https://www.renpy.org/doc/html/label.html) of the format
```python
label .local_name:
    # content
```
will now also be highlighted.

Please check the `RenpyLanguage.JSON-tmLanguage` file, since my build of Sublime only tests the newer `.tmLanguage` type file, but I'm pretty sure the change should work for that one as committed.